### PR TITLE
Add RGB565 mode for OV7725

### DIFF
--- a/components/camera/bitmap.c
+++ b/components/camera/bitmap.c
@@ -1,0 +1,26 @@
+//https://stackoverflow.com/a/23303847
+#include "bitmap.h"
+#include <string.h>
+#include <stdlib.h>
+
+
+char *bmp_create_header(int w, int h)
+{
+	bitmap *pbitmap  = (bitmap*)calloc(1, sizeof(bitmap));
+	int _pixelbytesize = w * h * _bitsperpixel/8;
+	int _filesize = _pixelbytesize+sizeof(bitmap);
+	strcpy((char*)pbitmap->fileheader.signature, "BM");
+	pbitmap->fileheader.filesize = _filesize;
+	pbitmap->fileheader.fileoffset_to_pixelarray = sizeof(bitmap);
+	pbitmap->bitmapinfoheader.dibheadersize = sizeof(bitmapinfoheader);
+	pbitmap->bitmapinfoheader.width = w;
+	pbitmap->bitmapinfoheader.height = h;
+	pbitmap->bitmapinfoheader.planes = _planes;
+	pbitmap->bitmapinfoheader.bitsperpixel = _bitsperpixel;
+	pbitmap->bitmapinfoheader.compression = _compression;
+	pbitmap->bitmapinfoheader.imagesize = _pixelbytesize;
+	pbitmap->bitmapinfoheader.ypixelpermeter = _ypixelpermeter ;
+	pbitmap->bitmapinfoheader.xpixelpermeter = _xpixelpermeter ;
+	pbitmap->bitmapinfoheader.numcolorspallette = 0;
+	return (char *)pbitmap;
+}

--- a/components/camera/camera.c
+++ b/components/camera/camera.c
@@ -91,6 +91,7 @@ static void dma_filter_task(void *pvParameters);
 static void dma_filter_grayscale(const dma_elem_t* src, lldesc_t* dma_desc, uint8_t* dst);
 static void dma_filter_grayscale_highspeed(const dma_elem_t* src, lldesc_t* dma_desc, uint8_t* dst);
 static void dma_filter_jpeg(const dma_elem_t* src, lldesc_t* dma_desc, uint8_t* dst);
+static void dma_filter_bitmap(const dma_elem_t* src, lldesc_t* dma_desc, uint8_t* dst);
 static void i2s_stop();
 
 static bool is_hs_mode()
@@ -236,6 +237,21 @@ esp_err_t camera_init(const camera_config_t* config)
         }
         s_state->in_bytes_per_pixel = 2;       // camera sends YUYV
         s_state->fb_bytes_per_pixel = 1;       // frame buffer stores Y8
+    } else if (pix_format == PIXFORMAT_RGB565) {
+        if (s_state->sensor.id.PID != OV7725_PID) {
+            ESP_LOGE(TAG, "Grayscale format is only supported for ov7225");
+            err = ESP_ERR_NOT_SUPPORTED;
+            goto fail;
+        }
+        s_state->fb_size = s_state->width * s_state->height * 3;
+        if (is_hs_mode()) {
+            s_state->sampling_mode = SM_0A0B_0B0C;
+        } else {
+            s_state->sampling_mode = SM_0A0B_0C0D;
+        }
+        s_state->dma_filter = &dma_filter_bitmap;
+        s_state->in_bytes_per_pixel = 2;       // camera sends YUYV
+        s_state->fb_bytes_per_pixel = 3;       // frame buffer stores Y8
     } else if (pix_format == PIXFORMAT_JPEG) {
         if (s_state->sensor.id.PID != OV2640_PID) {
             ESP_LOGE(TAG, "JPEG format is only supported for ov2640");
@@ -741,3 +757,50 @@ static void IRAM_ATTR dma_filter_jpeg(const dma_elem_t* src, lldesc_t* dma_desc,
         dst[3] = src[2].sample2;
     }
 }
+
+static void dma_filter_bitmap(const dma_elem_t* src, lldesc_t* dma_desc, uint8_t* dst)
+{
+    assert(s_state->sampling_mode == SM_0A0B_0B0C);
+
+    uint32_t rgb;
+    size_t end = dma_desc->length / sizeof(dma_elem_t) / 4;
+    for (size_t i = 0; i < end; ++i) {
+        // manually unrolling 4 iterations of the loop here
+        rgb = src[0].sample1;
+        rgb <<= 8;
+        rgb |= src[1].sample1;
+        dst[0] = (rgb & 0b1111100000000000) >> (8);
+        dst[1] = (rgb & 0b0000011111100000) >> (3);
+        dst[2] = (rgb & 0b0000000000011111) << 3;
+
+        rgb = src[2].sample1;
+        rgb <<= 8;
+        rgb |= src[3].sample1;
+
+        dst[4] = (rgb & 0b1111100000000000) >> (8);
+        dst[5] = (rgb & 0b0000011111100000) >> (3);
+        dst[6] = (rgb & 0b0000000000011111) << 3;
+
+        
+        dst += 6;
+        src += 4;
+    }
+    if ((dma_desc->length & 0x7) != 0) {
+        // manually unrolling 4 iterations of the loop here
+        rgb = src[0].sample1;
+        rgb <<= 8;
+        rgb |= src[1].sample1;
+        dst[0] = (rgb & 0b1111100000000000) >> (8);
+        dst[1] = (rgb & 0b0000011111100000) >> (3);
+        dst[2] = (rgb & 0b0000000000011111) << 3;
+
+        rgb = src[2].sample1;
+        rgb <<= 8;
+        rgb |= src[3].sample2;
+
+        dst[4] = (rgb & 0b1111100000000000) >> (8);
+        dst[5] = (rgb & 0b0000011111100000) >> (3);
+        dst[6] = (rgb & 0b0000000000011111) << 3;
+    }
+}
+

--- a/components/camera/include/bitmap.h
+++ b/components/camera/include/bitmap.h
@@ -1,0 +1,37 @@
+#ifndef _BITMAP_H_
+#define _BITMAP_H_
+#include <stdint.h>
+
+#define _bitsperpixel 24
+#define _planes 1
+#define _compression 0
+#define _xpixelpermeter 0x130B //2835 , 72 DPI
+#define _ypixelpermeter 0x130B //2835 , 72 DPI
+#define pixel 0xFF
+
+typedef struct __attribute__((packed, aligned(1))) {
+    uint8_t signature[2];
+    uint32_t filesize;
+    uint32_t reserved;
+    uint32_t fileoffset_to_pixelarray;
+} fileheader;
+typedef struct __attribute__((packed, aligned(1))) {
+    uint32_t dibheadersize;
+    uint32_t width;
+    uint32_t height;
+    uint16_t planes;
+    uint16_t bitsperpixel;
+    uint32_t compression;
+    uint32_t imagesize;
+    uint32_t ypixelpermeter;
+    uint32_t xpixelpermeter;
+    uint32_t numcolorspallette;
+    uint32_t mostimpcolor;
+} bitmapinfoheader;
+typedef struct {
+    fileheader fileheader;
+    bitmapinfoheader bitmapinfoheader;
+} bitmap;
+
+char *bmp_create_header(int w, int h);
+#endif

--- a/components/camera/ov7725.c
+++ b/components/camera/ov7725.c
@@ -143,7 +143,7 @@ static int set_pixformat(sensor_t *sensor, pixformat_t pixformat)
 
     switch (pixformat) {
         case PIXFORMAT_RGB565:
-            reg =  COM7_SET_FMT(reg, COM7_FMT_RGB);
+            reg =  COM7_SET_FMT(reg, COM7_FMT_RGB) | COM7_FMT_RGB565;
             break;
         case PIXFORMAT_YUV422:
         case PIXFORMAT_GRAYSCALE:


### PR DESCRIPTION
Implements #30 

Adds support for RGB565 bitmaps. These can be downloaded as single files or streamed like JPEGs.